### PR TITLE
edgeai-gst-apps: Align with codec changes for framerate

### DIFF
--- a/apps_cpp/common/src/edgeai_gst_wrapper.cpp
+++ b/apps_cpp/common/src/edgeai_gst_wrapper.cpp
@@ -314,9 +314,12 @@ int32_t GstPipe::getBuffer(const string        &name,
             gst_structure_get_int(strc, "height", &buf.height);
 
             sample = gst_sample_make_writable(sample);
-
-            gst_structure_set (strc, "framerate", GST_TYPE_FRACTION, 30, 1, NULL);
-            gst_structure_set (strc, "pixel-aspect-ratio", GST_TYPE_FRACTION, 1, 1, NULL);
+            gst_structure_set (strc,
+                               "pixel-aspect-ratio",
+                               GST_TYPE_FRACTION,
+                               1,
+                               1,
+                               NULL);
 
             gst_sample_set_caps(sample,caps);
             gst_caps_unref(caps);

--- a/apps_python/gst_wrapper.py
+++ b/apps_python/gst_wrapper.py
@@ -69,7 +69,7 @@ class GstPipe:
             + "width=%d, " % width
             + "height=%d, " % height
             + "format=RGB, "
-            + "framerate=%d/1" % fps
+            + "framerate=%s" % str(fps)
         )
         sink = self.sink_pipe.get_by_name(name)
         sink.set_caps(caps)

--- a/apps_python/infer_pipe.py
+++ b/apps_python/infer_pipe.py
@@ -54,18 +54,11 @@ class InferPipe:
         self.run_time = sub_flow.model.run_time
         self.post_proc = PostProcess.get(sub_flow)
 
-        """
-        Hack: Setting the appsrc framerate to a constant 30 because
-        v4l2h264enc does not work if the caps of appsrc is set to
-        some arbitary value like 1 (in case of image input). In reality
-        it should be set to 0 i.e dependent on imcoming data rate.
-        """
         self.gst_post_out = gst_pipe.get_sink(
             sub_flow.gst_post_sink_name,
             sub_flow.sensor_width,
             sub_flow.sensor_height,
-            30
-            # sub_flow.input.fps,
+            sub_flow.input.fps,
         )
         self.param = sub_flow.model
         self.pre_proc_debug = None


### PR DESCRIPTION
Codec supports arbitary framerate. Remove hack to explicitly set fps to 30 in appsrc

Signed-off-by: abhay <a-chirania@ti.com>