### PR TITLE
Fix OV5640 camera setup script

### DIFF
--- a/scripts/setup_cameras.sh
+++ b/scripts/setup_cameras.sh
@@ -182,7 +182,7 @@ setup_imx219(){
 }
 
 setup_ov5640(){
-    OV5640_CAM_FMT='[fmt:UYVY8_2X8/1280x720@1/30]'
+    OV5640_CAM_FMT='[fmt:UYVY8_1X16/1280x720@1/30]'
     for media_id in {0..1}; do
     for name in `media-ctl -d $media_id -p | grep entity | grep ov5640 | cut -d ' ' -f 5`; do
         CAM_SUBDEV=`media-ctl -d $media_id -p -e "ov5640 $name" | grep v4l-subdev | awk '{print $4}'`


### PR DESCRIPTION
For CSI-2, the correct formats to use for YUV422 are of the form 1x16 as it is a serial protocol. The formats of the form 2x8 are used for parallel protocols like DVP and 2x8 formats are deprecated in the CSI2RX bridge driver thus fix OV5640 format accordingly to use 1X16 instead.