### PR TITLE
edgeai-gst-apps: Use capture-io-mode as configurable property

### DIFF
--- a/apps_cpp/common/src/edgeai_demo_config.cpp
+++ b/apps_cpp/common/src/edgeai_demo_config.cpp
@@ -396,7 +396,23 @@ int32_t InputInfo::addGstPipeline(vector<vector<GstElement*>>   &preProcElementV
                 if (gVideoDecMap[m_format][i] == "v4l2h264dec" ||
                     gVideoDecMap[m_format][i] == "v4l2h265dec")
                 {
-                    m_gstElementProperty = {{"capture-io-mode","5"}};
+                    string capture_io_mode;
+                    if(gVideoDecMap[m_format][i] == "v4l2h264dec" &&
+                       gstElementMap["h264dec"]["property"] &&
+                       gstElementMap["h264dec"]["property"]["capture-io-mode"])
+                    {
+                        capture_io_mode = gstElementMap["h264dec"]["property"]["capture-io-mode"].as<string>();
+                        m_gstElementProperty = {{"capture-io-mode",capture_io_mode.c_str()}};
+                    }
+
+                    if(gVideoDecMap[m_format][i] == "v4l2h265dec" &&
+                       gstElementMap["h265dec"]["property"] &&
+                       gstElementMap["h265dec"]["property"]["capture-io-mode"])
+                    {
+                        capture_io_mode = gstElementMap["h265dec"]["property"]["capture-io-mode"].as<string>();
+                        m_gstElementProperty = {{"capture-io-mode",capture_io_mode.c_str()}};
+                    }
+
                     makeElement(m_inputElements,
                                 gVideoDecMap[m_format][i].c_str(),
                                 m_gstElementProperty,

--- a/apps_python/gst_wrapper.py
+++ b/apps_python/gst_wrapper.py
@@ -524,7 +524,11 @@ def get_input_elements(input):
 
     # Add decoder and caps if defined
     if gst_element_map["h264dec"]["element"] == "v4l2h264dec":
-        property = {"capture-io-mode": 5}
+        property = {}
+        if "property" in gst_element_map["h264dec"]:
+            if "capture-io-mode" in gst_element_map["h264dec"]["property"]:
+                property["capture-io-mode"] = \
+                            gst_element_map["h264dec"]["property"]["capture-io-mode"]
         video_dec["h264"].append(
             [gst_element_map["h264dec"]["element"], property, None]
         )
@@ -535,7 +539,11 @@ def get_input_elements(input):
         video_dec["h264"].append([gst_element_map["h264dec"]["element"], None, None])
 
     if gst_element_map["h265dec"]["element"] == "v4l2h265dec":
-        property = {"capture-io-mode": 5}
+        property = {}
+        if "property" in gst_element_map["h265dec"]:
+            if "capture-io-mode" in gst_element_map["h265dec"]["property"]:
+                property["capture-io-mode"] = \
+                            gst_element_map["h265dec"]["property"]["capture-io-mode"]
         video_dec["h265"].append(
             [gst_element_map["h265dec"]["element"], property, None]
         )

--- a/scripts/optiflow/gst_wrapper.py
+++ b/scripts/optiflow/gst_wrapper.py
@@ -62,18 +62,28 @@ def get_input_str(input):
     
 
     if gst_element_map["h264dec"]["element"] == "v4l2h264dec":
-        video_dec["h264"] += " ! v4l2h264dec capture-io-mode=5 " + \
-                             " ! tiovxmemalloc pool-size=8 " + \
-                             " ! video/x-raw, format=NV12 "
+        video_dec["h264"] += " ! v4l2h264dec"
+
+        if "property" in gst_element_map["h264dec"]:
+            if "capture-io-mode" in gst_element_map["h264dec"]["property"]:
+                video_dec["h264"] += " capture-io-mode=%s" % \
+                       gst_element_map["h264dec"]["property"]["capture-io-mode"]
+
+        video_dec["h264"] += " ! tiovxmemalloc pool-size=8" + \
+                             " ! video/x-raw, format=NV12"
     else:
-        video_dec["h264"] += " ! " + gst_element_map["h264dec"]["element"] + " "  
+        video_dec["h264"] += " ! " + gst_element_map["h264dec"]["element"]
     
     if gst_element_map["h265dec"]["element"] == "v4l2h265dec":
-        video_dec["h265"] += " ! v4l2h265dec capture-io-mode=5 " + \
-                             " ! tiovxmemalloc pool-size=8 " + \
-                             " ! video/x-raw, format=NV12 "
+        video_dec["h265"] += " ! v4l2h265dec"
+        if "property" in gst_element_map["h265dec"]:
+            if "capture-io-mode" in gst_element_map["h265dec"]["property"]:
+                video_dec["h265"] += " capture-io-mode=%s" % \
+                       gst_element_map["h265dec"]["property"]["capture-io-mode"]
+        video_dec["h265"] += " ! tiovxmemalloc pool-size=8" + \
+                             " ! video/x-raw, format=NV12"
     else:
-        video_dec["h265"] += " ! " + gst_element_map["h265dec"]["element"] + " "
+        video_dec["h265"] += " ! " + gst_element_map["h265dec"]["element"]
 
     source_ext = os.path.splitext(input.source)[1]
     status = 0
@@ -189,7 +199,7 @@ def get_input_str(input):
     elif (source == 'rtsp'):
         source_cmd = 'rtspsrc location=' + input.source + \
                      ' latency=0 buffer-mode=auto ! rtph264depay' + \
-                     video_dec["h264"]
+                     video_dec["h264"] + ' ! '
 
     elif (source == 'image'):
         source_cmd = 'multifilesrc location=' + input.source


### PR DESCRIPTION
Use capture-io-mode as configurable property for decoder. It can be defined in gst_plugins_map file