### PR TITLE
edgeai-gst-apps: Add support to define c7x and viss target

### DIFF
--- a/apps_python/edge_ai_class.py
+++ b/apps_python/edge_ai_class.py
@@ -37,13 +37,13 @@ import utils
 import sys
 import os
 
-
 class EdgeAIDemo:
     """
     Abstract the functionality required for the Edge AI demo.
     Creates Input, Model, Output and Flow objects. Sets up infer pipes
     for each flow and starts the infer pipes
     """
+    C7_CORE_ID_INDEX = 0
 
     def __init__(self, config):
         """
@@ -89,7 +89,19 @@ class EdgeAIDemo:
                 model_config =  config["models"][model]
                 model_path = model_config["model_path"]
                 # Make model Config. This class is present in edgeai_dl_inferer
-                model_obj = ModelConfig(model_path,gst_element_map["enable-tidl"],1)
+                enable_tidl = False
+                core_id = 1
+                if (gst_element_map['inferer']['target'] == 'dsp'):
+                    enable_tidl = True
+                    if 'core-id' in gst_element_map['inferer']:
+                        core_id = gst_element_map['inferer']['core-id'][EdgeAIDemo.C7_CORE_ID_INDEX]
+                        EdgeAIDemo.C7_CORE_ID_INDEX += 1
+                        if EdgeAIDemo.C7_CORE_ID_INDEX >= len(gst_element_map['inferer']['core-id']):
+                            EdgeAIDemo.C7_CORE_ID_INDEX = 0
+                elif (gst_element_map['inferer']['target'] != 'arm'):
+                    print("[WARNING] Invalid target specified for inferer. Defaulting to ARM.")
+
+                model_obj = ModelConfig(model_path,enable_tidl,core_id)
                 # task specific params
                 if "alpha" in model_config:
                     model_obj.alpha = model_config["alpha"]

--- a/configs/gst_plugins_map.yaml
+++ b/configs/gst_plugins_map.yaml
@@ -43,7 +43,9 @@ j721e:
         property:
             bitrate: 10000000
     h265enc: null
-    enable-tidl: true
+    inferer:
+        target: dsp
+        core-id: [1]
 
 #==================== J721S2 ====================
 j721s2:
@@ -78,7 +80,9 @@ j721s2:
             bitrate: 10000000
     h265enc:
         element: v4l2h265enc
-    enable-tidl: true
+    inferer:
+        target: dsp
+        core-id: [1]
 
 #==================== J784S4 ====================
 j784s4:
@@ -101,8 +105,12 @@ j784s4:
         element: tiovxmosaic
     isp:
         element: tiovxisp
+        property:
+            target: [0,1]
     ldc:
         element: tiovxldc
+        property:
+            target: [0,1]
     h264dec:
         element: v4l2h264dec
     h265dec:
@@ -113,7 +121,9 @@ j784s4:
             bitrate: 10000000
     h265enc:
         element: v4l2h265enc
-    enable-tidl: true
+    inferer:
+        target: dsp
+        core-id: [1,2,3,4]
 
 #==================== AM62A ====================
 am62a:
@@ -143,7 +153,9 @@ am62a:
         element: v4l2h264enc
     h265enc:
         element: v4l2h265enc
-    enable-tidl: true
+    inferer:
+        target: dsp
+        core-id: [1]
 
 #==================== AM62X ====================
 am62:
@@ -165,8 +177,8 @@ am62:
         element: v4l2h264enc
     h265enc:
         element: v4l2h265enc
-    enable-tidl: false
-
+    inferer:
+        target: arm
 #==================== ARM-ONLY ====================
 arm:
     dlcolorconvert:
@@ -187,4 +199,5 @@ arm:
         element: v4l2h264enc
     h265enc:
         element: v4l2h265enc
-    enable-tidl: false
+    inferer:
+        target: arm

--- a/scripts/optiflow/optiflow_class.py
+++ b/scripts/optiflow/optiflow_class.py
@@ -35,6 +35,9 @@ import sys
 from gst_element_map import gst_element_map
 
 class OptiFlowClass:
+
+    C7_CORE_ID_INDEX = 0
+
     def __init__(self, config):
         """
         Constructor of EdgeAIDemo class
@@ -78,7 +81,19 @@ class OptiFlowClass:
                 model_config =  config["models"][model]
                 model_path = model_config["model_path"]
                 # Make model Config. This class is present in edgeai_dl_inferer
-                model_obj = ModelConfig(model_path,gst_element_map["enable-tidl"],1)
+                enable_tidl = False
+                core_id = 1
+                if (gst_element_map['inferer']['target'] == 'dsp'):
+                    enable_tidl = True
+                    if 'core-id' in gst_element_map['inferer']:
+                        core_id = gst_element_map['inferer']['core-id'][OptiFlowClass.C7_CORE_ID_INDEX]
+                        OptiFlowClass.C7_CORE_ID_INDEX += 1
+                        if OptiFlowClass.C7_CORE_ID_INDEX >= len(gst_element_map['inferer']['core-id']):
+                            OptiFlowClass.C7_CORE_ID_INDEX = 0
+                elif (gst_element_map['inferer']['target'] != 'arm'):
+                    print("[WARNING] Invalid target specified for inferer. Defaulting to ARM.")
+
+                model_obj = ModelConfig(model_path,enable_tidl,core_id)
                 # task specific params
                 if "alpha" in model_config:
                     model_obj.alpha = model_config["alpha"]


### PR DESCRIPTION
Add support to define list of c7x and viss targets available on SOC. Pipeline is constructed with target selected in a round-robin manner.