### PR TITLE
encoder: Change the way bitrate and gop-size is set

### DIFF
--- a/apps_cpp/common/src/edgeai_demo_config.cpp
+++ b/apps_cpp/common/src/edgeai_demo_config.cpp
@@ -1316,8 +1316,13 @@ int32_t OutputInfo::appendGstPipeline()
     {
         for(unsigned i=0;i<gVideoEncMap[sinkExt].size();i++)
         {
+            string encoder_extra_ctrl = "controls"
+                                        ", frame_level_rate_control_enable=1"
+                                        ", video_bitrate=" + to_string(m_bitrate) +
+                                        ", video_gop_size=" + to_string(m_gopSize);
             if (gVideoEncMap[sinkExt][i] == "v4l2h264enc")
-                m_gstElementProperty = {{"bitrate",to_string(m_bitrate).c_str()}};
+                m_gstElementProperty = {{"extra-controls",encoder_extra_ctrl.c_str()}};
+
             makeElement(m_dispElements,
                         gVideoEncMap[sinkExt][i].c_str(),
                         m_gstElementProperty,
@@ -1331,8 +1336,11 @@ int32_t OutputInfo::appendGstPipeline()
     }
     else if (sinkType == "remote")
     {
-        m_gstElementProperty = {{"gop-size",to_string(m_gopSize).c_str()},
-                                {"bitrate",to_string(m_bitrate).c_str()}};
+        string encoder_extra_ctrl = "controls"
+                                    ", frame_level_rate_control_enable=1"
+                                    ", video_bitrate=" + to_string(m_bitrate) +
+                                    ", video_gop_size=" + to_string(m_gopSize);
+        m_gstElementProperty = {{"extra-controls",encoder_extra_ctrl.c_str()}};
 
         makeElement(m_dispElements,"v4l2h264enc",m_gstElementProperty,NULL);
         makeElement(m_dispElements,"h264parse",m_gstElementProperty,NULL);

--- a/apps_python/gst_wrapper.py
+++ b/apps_python/gst_wrapper.py
@@ -902,19 +902,23 @@ def get_output_elements(output):
     """
     image_enc = {".jpg": "jpegenc"}
 
+    prop_str = "video_bitrate=%d, video_gop_size=%d" \
+                                              % (output.bitrate,output.gop_size)
+    enc_extra_ctrl = "controls, frame_level_rate_control_enable=1, " + prop_str
+
     video_enc = {
         ".mov": [
-            ["v4l2h264enc", {"bitrate": output.bitrate}],
+            ["v4l2h264enc", {"extra-controls": enc_extra_ctrl}],
             ["h264parse", None],
             ["qtmux", None],
         ],
         ".mp4": [
-            ["v4l2h264enc", {"bitrate": output.bitrate}],
+            ["v4l2h264enc", {"extra-controls": enc_extra_ctrl}],
             ["h264parse", None],
             ["mp4mux", None],
         ],
         ".mkv": [
-            ["v4l2h264enc", {"bitrate": output.bitrate}],
+            ["v4l2h264enc", {"extra-controls": enc_extra_ctrl}],
             ["h264parse", None],
             ["matroskamux", None],
         ],
@@ -971,7 +975,7 @@ def get_output_elements(output):
     elif sink == "remote":
         property = {}
         if output.encoder == "v4l2h264enc":
-            property = {"gop-size": output.gop_size, "bitrate": output.bitrate}
+            property = {"extra-controls": enc_extra_ctrl}
 
         sink_elements += make_element(output.encoder, property=property)
 

--- a/configs/gst_plugins_map.yaml
+++ b/configs/gst_plugins_map.yaml
@@ -40,8 +40,6 @@ j721e:
         element: v4l2h265dec
     h264enc:
         element: v4l2h264enc
-        property:
-            bitrate: 10000000
     h265enc: null
     inferer:
         target: dsp
@@ -76,8 +74,6 @@ j721s2:
         element: v4l2h265dec
     h264enc:
         element: v4l2h264enc
-        property:
-            bitrate: 10000000
     h265enc:
         element: v4l2h265enc
     inferer:
@@ -117,8 +113,6 @@ j784s4:
         element: v4l2h265dec
     h264enc:
         element: v4l2h264enc
-        property:
-            bitrate: 10000000
     h265enc:
         element: v4l2h265enc
     inferer:


### PR DESCRIPTION
gstreamer 1.20 changes the way bitrate and gop-size is set for v4l2h264enc. Align with same.