### PR TITLE
Change the way remote streaming config is written.

### DIFF
--- a/apps_cpp/common/include/edgeai_demo_config.h
+++ b/apps_cpp/common/include/edgeai_demo_config.h
@@ -447,10 +447,10 @@ namespace ti::edgeai::common
              */
             int32_t                         m_port{8081};
 
-            /** Payloader for remote sink.
+            /** Encoding type for remote sink.
              * This field is ignored for sinks other than remote
              */
-            string                          m_payloader{"rtph264pay"};
+            string                          m_encoding{"h264"};
 
             /** gop size for encoder.
              */

--- a/apps_cpp/common/src/edgeai_gst_helper.cpp
+++ b/apps_cpp/common/src/edgeai_gst_helper.cpp
@@ -73,6 +73,12 @@ namespace ti::edgeai::common
                              gst_caps_from_string(propMap[i][1]),
                              NULL);
             }
+            else if (g_str_equal(propMap[i][0],"extra-controls"))
+            {
+                g_object_set(element,propMap[i][0],
+                             gst_structure_from_string(propMap[i][1],NULL),
+                             NULL);
+            }
             else if (g_str_equal(propMap[i][1],"true") ||
                      g_str_equal(propMap[i][1],"false") )
             {
@@ -759,6 +765,7 @@ namespace ti::edgeai::common
                         }
                         break;
                     }
+
                     default:
                         if (element_name == "capsfilter" && param->value_type == GST_TYPE_CAPS)
                         {
@@ -769,7 +776,19 @@ namespace ti::edgeai::common
                                 data += param->name;
                                 data += "=\"";
                                 data += gst_caps_to_string(caps);
-                                data += "; \"";
+                                data += ";\"";
+                            }
+                        }
+                        else if (param->value_type == GST_TYPE_STRUCTURE)
+                        {
+                            const GstStructure *st = gst_value_get_structure (&value);
+                            if (st != NULL)
+                            {
+                                data += " ";
+                                data += param->name;
+                                data += "=\"";
+                                data += gst_structure_to_string(st);
+                                data += "\"";
                             }
                         }
 

--- a/apps_python/config_parser.py
+++ b/apps_python/config_parser.py
@@ -101,14 +101,10 @@ class Output:
             self.host = output_config["host"]
         else:
             self.host = "0.0.0.0"
-        if "payloader" in output_config:
-            self.payloader = output_config["payloader"]
+        if 'encoding' in output_config:
+            self.encoding = output_config['encoding']
         else:
-            self.payloader = "rtph264pay"
-        if "encoder" in output_config:
-            self.encoder = output_config["encoder"]
-        else:
-            self.encoder = "v4l2h264enc"
+            self.encoding = 'h264'
         if "gop-size" in output_config:
             self.gop_size = output_config["gop-size"]
         else:

--- a/apps_python/utils.py
+++ b/apps_python/utils.py
@@ -315,6 +315,9 @@ def get_name_with_prop(element):
                     if GObject.GType.is_a(i.value_type, GObject.GEnum):
                         element_prop += " " + i.name + "="
                         element_prop += str(int(element.get_property(i.name)))
+                    elif GObject.GType.is_a(i.value_type, GObject.TYPE_BOXED):
+                        element_prop += " " + i.name + "="
+                        element_prop += "\"" + Gst.Structure.to_string(element.get_property(i.name)) + "\""
                     elif is_appropriate_value_type(i):
                         element_prop += " " + i.name + "="
                         element_prop += str(element.get_property(i.name))

--- a/configs/app_config_template.yaml
+++ b/configs/app_config_template.yaml
@@ -194,25 +194,26 @@ models:
 # Application output configuration. This is a list of outputs
 # enumerated starting with 0.
 outputs:
+    # Allowed sink for the output. Allowed values
+    # - kmssink                 [Display]
+    # - <some_path>/*%Nd*.jpg   [Image]
+    # - <some_path>/*.mkv       [Video]
+    # - <some_path>/*.mp4       [Video]
+    # - <some_path>/*.mov       [Video]
+    # - remote                  [Remote]
+    #
+    #ex:- ../c/d/output_image%02d.jpg
+    #     /a/b/c/d/output_image%02d.png
+    #     /a/b/c/d/output_video.mkv
+    #     /a/b/c/d/output_video.mp4
+    #     /a/b/c/d/output_video.mov
+    #
+    # The paths to images and videos can be absolute or relative to the directoty
+    # the application is launched from.
+    #
+    # Default is kmssink
     output0:
-        # Allowed sink for the output. Allowed values
-        # - kmssink                 [Display]
-        # - <some_path>/*%Nd*.jpg   [Image]
-        # - <some_path>/*%Nd*.png   [Image]
-        # - <some_path>/*.mkv       [Video]
-        # - <some_path>/*.mp4       [Video]
-        # - <some_path>/*.mov       [Video]
-        #
-        #ex:- ../c/d/output_image%02d.jpg
-        #     /a/b/c/d/output_image%02d.png
-        #     /a/b/c/d/output_video.mkv
-        #     /a/b/c/d/output_video.mp4
-        #     /a/b/c/d/output_video.mov
-        #
-        # The paths to images and videos can be absolute or relative to the directoty
-        # the application is launched from.
-        #
-        # Default is kmssink
+        # Display
         sink: kmssink
 
         # Output display width
@@ -229,24 +230,7 @@ outputs:
         connector: 0
 
     output1:
-        # Allowed sink for the output. Allowed values
-        # - kmssink                 [Display]
-        # - <some_path>/*%Nd*.jpg   [Image]
-        # - <some_path>/*%Nd*.png   [Image]
-        # - <some_path>/*.mkv       [Video]
-        # - <some_path>/*.mp4       [Video]
-        # - <some_path>/*.mov       [Video]
-        #
-        #ex:- ../c/d/output_image%02d.jpg
-        #     /a/b/c/d/output_image%02d.png
-        #     /a/b/c/d/output_video.mkv
-        #     /a/b/c/d/output_video.mp4
-        #     /a/b/c/d/output_video.mov
-        #
-        # The paths to images and videos can be absolute or relative to the directoty
-        # the application is launched from.
-        #
-        # Default is kmssink
+        # Save as video
         sink: /opt/edgeai-test-data/output/output_video.mkv
 
         # Output display width
@@ -257,25 +241,9 @@ outputs:
 
         #Bitrate of encoder (optional)(Default=10000000)
         bitrate: 10000000
+
     output2:
-        # Allowed sink for the output. Allowed values
-        # - kmssink                 [Display]
-        # - <some_path>/*%Nd*.jpg   [Image]
-        # - <some_path>/*%Nd*.png   [Image]
-        # - <some_path>/*.mkv       [Video]
-        # - <some_path>/*.mp4       [Video]
-        # - <some_path>/*.mov       [Video]
-        #
-        #ex:- ../c/d/output_image%02d.jpg
-        #     /a/b/c/d/output_image%02d.png
-        #     /a/b/c/d/output_video.mkv
-        #     /a/b/c/d/output_video.mp4
-        #     /a/b/c/d/output_video.mov
-        #
-        # The paths to images and videos can be absolute or relative to the directoty
-        # the application is launched from.
-        #
-        # Default is kmssink
+        # Save as image
         sink: /opt/edgeai-test-data/output/output_image_%04d.jpg
 
         # Output display width
@@ -283,8 +251,9 @@ outputs:
 
         # Output display height
         height: 1080
+
     output3:
-        # Sink for display on browser
+        # Encode and stream over network
         sink: remote
 
         # Output display width
@@ -299,22 +268,14 @@ outputs:
         #IP group to send the packets to(optional)(Default=0.0.0.0)
         host: 127.0.0.1
 
-        #Encoder to be used
+        #Encoding to be used
         # Ex:
-        # - v4l2h264enc
-        # - jpegenc
+        # - jpeg
+        # - mp4
+        # - h264
         #
-        # Optional - (Default=v4l2h264enc)
-        encoder: v4l2h264enc
-
-        #Payloader or Mux to be added after encode
-        # Ex:
-        # - rtph264pay
-        # - mp4mux
-        # - multipartmux
-        #
-        # Optional - (Default=rtph264pay)
-        payloader: rtph264pay
+        # Optional - (Default=h264)
+        encoding: jpeg
         
         #Bitrate of encoder (optional)(Default=10000000)
         bitrate: 10000000

--- a/configs/face_detection.yaml
+++ b/configs/face_detection.yaml
@@ -31,18 +31,7 @@ outputs:
         height: 1080
         port: 8081
         host: 127.0.0.1
-        encoder: jpegenc
-        payloader: multipartmux
-        overlay-performance: True
-    output4:
-        sink: remote
-        width: 1920
-        height: 1080
-        port: 8081
-        host: 127.0.0.1
-        encoder: v4l2h264enc
-        payloader: mp4mux
-        bitrate: 1000000
+        encoding: jpeg
         overlay-performance: True
 
 flows:

--- a/configs/gst_plugins_map.yaml
+++ b/configs/gst_plugins_map.yaml
@@ -41,6 +41,8 @@ j721e:
     h264enc:
         element: v4l2h264enc
     h265enc: null
+    jpegenc:
+        element: jpegenc
     inferer:
         target: dsp
         core-id: [1]
@@ -76,6 +78,8 @@ j721s2:
         element: v4l2h264enc
     h265enc:
         element: v4l2h265enc
+    jpegenc:
+        element: jpegenc
     inferer:
         target: dsp
         core-id: [1]
@@ -115,6 +119,8 @@ j784s4:
         element: v4l2h264enc
     h265enc:
         element: v4l2h265enc
+    jpegenc:
+        element: jpegenc
     inferer:
         target: dsp
         core-id: [1,2,3,4]
@@ -147,6 +153,8 @@ am62a:
         element: v4l2h264enc
     h265enc:
         element: v4l2h265enc
+    jpegenc:
+        element: jpegenc
     inferer:
         target: dsp
         core-id: [1]
@@ -175,6 +183,8 @@ am62x:
         element: v4l2h264enc
     h265enc:
         element: v4l2h265enc
+    jpegenc:
+        element: jpegenc
     inferer:
         target: arm
 #==================== ARM-ONLY ====================
@@ -197,5 +207,7 @@ arm:
         element: v4l2h264enc
     h265enc:
         element: v4l2h265enc
+    jpegenc:
+        element: jpegenc
     inferer:
         target: arm

--- a/configs/http_src_example.yaml
+++ b/configs/http_src_example.yaml
@@ -33,23 +33,11 @@ outputs:
         height: 720
     output3:
         sink: remote
-        width: 1280
-        height: 720
+        width: 1920
+        height: 1080
         port: 8081
         host: 127.0.0.1
-        encoder: jpegenc
-        payloader: multipartmux
+        encoding: jpeg
         overlay-performance: True
-    output4:
-        sink: remote
-        width: 1280
-        height: 720
-        port: 8081
-        host: 127.0.0.1
-        encoder: v4l2h264enc
-        payloader: mp4mux
-        bitrate: 1000000
-        overlay-performance: True
-
 flows:
     flow0: [input0,model1,output0,[320,120,640,480]]

--- a/configs/image_classification.yaml
+++ b/configs/image_classification.yaml
@@ -51,18 +51,7 @@ outputs:
         height: 1080
         port: 8081
         host: 127.0.0.1
-        encoder: jpegenc
-        payloader: multipartmux
-        overlay-performance: True
-    output4:
-        sink: remote
-        width: 1920
-        height: 1080
-        port: 8081
-        host: 127.0.0.1
-        encoder: v4l2h264enc
-        payloader: mp4mux
-        bitrate: 1000000
+        encoding: jpeg
         overlay-performance: True
 
 flows:

--- a/configs/imx390_cam_example.yaml
+++ b/configs/imx390_cam_example.yaml
@@ -44,18 +44,7 @@ outputs:
         height: 1080
         port: 8081
         host: 127.0.0.1
-        encoder: jpegenc
-        payloader: multipartmux
-        overlay-performance: True
-    output4:
-        sink: remote
-        width: 1920
-        height: 1080
-        port: 8081
-        host: 127.0.0.1
-        encoder: v4l2h264enc
-        payloader: mp4mux
-        bitrate: 1000000
+        encoding: jpeg
         overlay-performance: True
 
 flows:

--- a/configs/multi_input_multi_infer.yaml
+++ b/configs/multi_input_multi_infer.yaml
@@ -54,18 +54,7 @@ outputs:
         height: 1080
         port: 8081
         host: 127.0.0.1
-        encoder: jpegenc
-        payloader: multipartmux
-        overlay-performance: True
-    output4:
-        sink: remote
-        width: 1920
-        height: 1080
-        port: 8081
-        host: 127.0.0.1
-        encoder: v4l2h264enc
-        payloader: mp4mux
-        bitrate: 1000000
+        encoding: jpeg
         overlay-performance: True
 
 flows:

--- a/configs/object_detection.yaml
+++ b/configs/object_detection.yaml
@@ -51,18 +51,7 @@ outputs:
         height: 1080
         port: 8081
         host: 127.0.0.1
-        encoder: jpegenc
-        payloader: multipartmux
-        overlay-performance: True
-    output4:
-        sink: remote
-        width: 1920
-        height: 1080
-        port: 8081
-        host: 127.0.0.1
-        encoder: v4l2h264enc
-        payloader: mp4mux
-        bitrate: 1000000
+        encoding: jpeg
         overlay-performance: True
 
 flows:

--- a/configs/ov5640_sensor_example.yaml
+++ b/configs/ov5640_sensor_example.yaml
@@ -39,18 +39,7 @@ outputs:
         height: 1080
         port: 8081
         host: 127.0.0.1
-        encoder: jpegenc
-        payloader: multipartmux
-        overlay-performance: True
-    output4:
-        sink: remote
-        width: 1920
-        height: 1080
-        port: 8081
-        host: 127.0.0.1
-        encoder: v4l2h264enc
-        payloader: mp4mux
-        bitrate: 1000000
+        encoding: jpeg
         overlay-performance: True
 
 flows:

--- a/configs/remote_display.yaml
+++ b/configs/remote_display.yaml
@@ -39,24 +39,22 @@ outputs:
     # Jpeg encode and stream
     output0:
         sink: remote
-        width: 1920
-        height: 1080
+        width: 1280
+        height: 720
         port: 8081
         host: 127.0.0.1
-        encoder: jpegenc
-        payloader: multipartmux
+        encoding: jpeg
         overlay-performance: True
     # mp4 encode and stream
     output1:
         sink: remote
-        width: 1920
-        height: 1080
+        width: 1280
+        height: 720
         port: 8081
         host: 127.0.0.1
-        encoder: v4l2h264enc
-        payloader: mp4mux
+        encoding: mp4
         bitrate: 1000000
         overlay-performance: True
 
 flows:
-    flow0: [input0,model1,output0,[320,150,1280,720]]
+    flow0: [input1,model1,output0]

--- a/configs/rpiV2_cam_example.yaml
+++ b/configs/rpiV2_cam_example.yaml
@@ -41,18 +41,7 @@ outputs:
         height: 1080
         port: 8081
         host: 127.0.0.1
-        encoder: jpegenc
-        payloader: multipartmux
-        overlay-performance: True
-    output4:
-        sink: remote
-        width: 1920
-        height: 1080
-        port: 8081
-        host: 127.0.0.1
-        encoder: v4l2h264enc
-        payloader: mp4mux
-        bitrate: 1000000
+        encoding: jpeg
         overlay-performance: True
 
 flows:

--- a/configs/rtsp_src_example.yaml
+++ b/configs/rtsp_src_example.yaml
@@ -40,18 +40,7 @@ outputs:
         height: 1080
         port: 8081
         host: 127.0.0.1
-        encoder: jpegenc
-        payloader: multipartmux
-        overlay-performance: True
-    output4:
-        sink: remote
-        width: 1920
-        height: 1080
-        port: 8081
-        host: 127.0.0.1
-        encoder: v4l2h264enc
-        payloader: mp4mux
-        bitrate: 1000000
+        encoding: jpeg
         overlay-performance: True
 
 flows:

--- a/configs/semantic_segmentation.yaml
+++ b/configs/semantic_segmentation.yaml
@@ -51,18 +51,7 @@ outputs:
         height: 1080
         port: 8081
         host: 127.0.0.1
-        encoder: jpegenc
-        payloader: multipartmux
-        overlay-performance: True
-    output4:
-        sink: remote
-        width: 1920
-        height: 1080
-        port: 8081
-        host: 127.0.0.1
-        encoder: v4l2h264enc
-        payloader: mp4mux
-        bitrate: 1000000
+        encoding: jpeg
         overlay-performance: True
 
 flows:

--- a/configs/shared_model_instance.yaml
+++ b/configs/shared_model_instance.yaml
@@ -45,18 +45,7 @@ outputs:
         height: 1080
         port: 8081
         host: 127.0.0.1
-        encoder: jpegenc
-        payloader: multipartmux
-        overlay-performance: True
-    output4:
-        sink: remote
-        width: 1920
-        height: 1080
-        port: 8081
-        host: 127.0.0.1
-        encoder: v4l2h264enc
-        payloader: mp4mux
-        bitrate: 1000000
+        encoding: jpeg
         overlay-performance: True
 
 flows:

--- a/configs/single_input_multi_infer.yaml
+++ b/configs/single_input_multi_infer.yaml
@@ -54,18 +54,7 @@ outputs:
         height: 1080
         port: 8081
         host: 127.0.0.1
-        encoder: jpegenc
-        payloader: multipartmux
-        overlay-performance: True
-    output4:
-        sink: remote
-        width: 1920
-        height: 1080
-        port: 8081
-        host: 127.0.0.1
-        encoder: v4l2h264enc
-        payloader: mp4mux
-        bitrate: 1000000
+        encoding: jpeg
         overlay-performance: True
 
 flows:

--- a/optiflow/config_parser.py
+++ b/optiflow/config_parser.py
@@ -131,14 +131,10 @@ class Output:
             self.host = output_config['host']
         else:
             self.host = '0.0.0.0'
-        if 'payloader' in output_config:
-            self.payloader = output_config['payloader']
+        if 'encoding' in output_config:
+            self.encoding = output_config['encoding']
         else:
-            self.payloader = 'rtph264pay'
-        if 'encoder' in output_config:
-            self.encoder = output_config['encoder']
-        else:
-            self.encoder = 'v4l2h264enc'
+            self.encoding = 'h264'
         if 'gop-size' in output_config:
             self.gop_size = output_config['gop-size']
         else:

--- a/scripts/remote_streaming/server.js
+++ b/scripts/remote_streaming/server.js
@@ -123,7 +123,6 @@ app.get('/mp4', function (req, res) {
   });
   console.log(req.params.id)
   emitter.on('data', function(data) {
-      console.log('data event received...');
       const chunk = data.length
       if(chunk > 0){
           res.write(data)


### PR DESCRIPTION
Change the way remote output config is written.
Instead of encoder and payloader, mention just
encoding type.

Also add jpegenc to gst_plugins_map to use diff
jpegencoders across SOC.

Also set bitrate and gop-size property for
v4l2h264enc in apps_python and apps_cpp properly.