### PR TITLE
Remove "caps" property from multifilesrc for h264/h265 videos

### DIFF
--- a/apps_cpp/common/src/edgeai_demo_config.cpp
+++ b/apps_cpp/common/src/edgeai_demo_config.cpp
@@ -424,41 +424,11 @@ int32_t InputInfo::addGstPipeline(vector<vector<GstElement*>>   &preProcElementV
                 m_format = "auto";
             }
 
-            string multifile_caps = "";
-            if ((m_format == "h264" &&
-                 gstElementMap["h264dec"]["element"].as<string>() == "v4l2h264dec")
-                ||
-                (m_format == "h265" &&
-                 gstElementMap["h264dec"]["element"].as<string>() == "v4l2h265dec"))
-            {
-                multifile_caps = "video/x-" +
-                                 m_format +
-                                 ",width=" +
-                                 to_string(m_width) +
-                                 ",height=" +
-                                 to_string(m_height) +
-                                 ",framerate=" +
-                                 m_framerate;
-            }
-
-            if (multifile_caps != "")
-            {
-                m_gstElementProperty = {{"location",m_source.c_str()},
-                                        {"loop",to_string(m_loop).c_str()},
-                                        {"stop-index",to_string(indexEnd).c_str()},
-                                        {"caps",multifile_caps.c_str()},
-                                        {"name",srcName.c_str()}
-                                        };
-            }
-
-            else
-            {
-                m_gstElementProperty = {{"location",m_source.c_str()},
-                                        {"loop",to_string(m_loop).c_str()},
-                                        {"stop-index",to_string(indexEnd).c_str()},
-                                        {"name",srcName.c_str()}
-                                        };
-            }
+            m_gstElementProperty = {{"location",m_source.c_str()},
+                                    {"loop",to_string(m_loop).c_str()},
+                                    {"stop-index",to_string(indexEnd).c_str()},
+                                    {"name",srcName.c_str()}
+                                    };
 
             makeElement(m_inputElements,"multifilesrc",m_gstElementProperty, NULL);
 

--- a/apps_python/gst_wrapper.py
+++ b/apps_python/gst_wrapper.py
@@ -751,12 +751,6 @@ def get_input_elements(input):
         if input.loop == True:
             property["loop"] = True
 
-        #Set caps only in case of hardware decoder
-        if ((input.format == "h264" and gst_element_map["h264dec"]["element"] == "v4l2h264dec") or
-            (input.format == "h265" and gst_element_map["h264dec"]["element"] == "v4l2h264dec")):
-            caps_string = "video/x-" + input.format
-            caps_string += ",width=%d,height=%d,framerate=%s" % (input.width,input.height,input.fps)
-            property["caps"] = Gst.caps_from_string(caps_string)
         element = make_element("multifilesrc", property=property)
         input_element_list += element
         for i in video_dec[input.format]:

--- a/optiflow/gst_wrapper.py
+++ b/optiflow/gst_wrapper.py
@@ -281,13 +281,6 @@ def get_input_str(input):
     elif (source == 'raw_video'):
         source_cmd = 'multifilesrc location=' + input.source
         source_cmd += ' loop=true stop-index=-1' if input.loop else ' loop=false stop-index=0'
-
-        # Set caps only in case of hardware decoder
-        if ((input.format == "h264" and gst_element_map["h264dec"]["element"] == "v4l2h264dec") or
-            (input.format == "h265" and gst_element_map["h264dec"]["element"] == "v4l2h264dec")):
-            source_cmd += ' caps=video/x-' + input.format
-            source_cmd += ',width=%d,height=%d,framerate=%d/1' % (input.width,input.height,input.fps)
-
         source_cmd +=  video_dec[input.format]
         source_cmd += ' ! '
 


### PR DESCRIPTION
ADASVISION-5922. This removes gstreamer critical warning