### PR TITLE
Robotics SDK instllation script update for 9.1 

### DIFF
--- a/scripts/install_robotics_sdk.sh
+++ b/scripts/install_robotics_sdk.sh
@@ -78,7 +78,7 @@ function git_checkout_with_tag {
     fi
 }
 
-# "git pull"" to the current folder
+# "git pull" to the current folder
 function git_pull_to_current_folder {
     git init
     git remote add origin $GIT_REPO
@@ -115,7 +115,7 @@ if [[ -f "$SDK_DIR/scripts/install_mmwave_rospkg.sh" ]]; then
 fi
 
 # Setup $WORK_DIR
-mkdir -p $ROS_WS
+mkdir -p $WORK_DIR
 cd $WORK_DIR
 ln -sf $SDK_DIR/docker/Makefile $WORK_DIR/Makefile
 if [[ "$ARCH" == "aarch64" ]]; then


### PR DESCRIPTION
install_robotics_sdk.sh: Updated not to create ros_ws folder. ros_ws is now created as a symbolic link with entrypoint.sh at docker_run time.