### PR TITLE
Change self.bus.timed_pop_filtered to bus.timed_pop_filtered in gst_w…

### DIFF
--- a/optiflow/gst_wrapper.py
+++ b/optiflow/gst_wrapper.py
@@ -73,7 +73,7 @@ class GstPipe:
         bus = self.pipeline.get_bus()
         ret = self.pipeline.set_state(Gst.State.PLAYING)
         if ret == Gst.StateChangeReturn.FAILURE:
-            msg = self.bus.timed_pop_filtered(Gst.CLOCK_TIME_NONE, Gst.MessageType.ERROR)
+            msg = bus.timed_pop_filtered(Gst.CLOCK_TIME_NONE, Gst.MessageType.ERROR)
             err, debug_info = msg.parse_error()
             print("[ERROR]", err.message)
             sys.exit(1)


### PR DESCRIPTION
…rapper.py

https://github.com/TexasInstruments/edgeai-gst-apps/issues/178 In line 76 of optiflow/gst_wrapper.py self.bus.timed_pop_filtered should be bus.timed_pop_filtered as there is no self.bus in the code.