### PR TITLE
edgeai-gst-apps: Bump up to 11_01_00

### DIFF
--- a/docker/setup_ti_processor_sdk.sh
+++ b/docker/setup_ti_processor_sdk.sh
@@ -45,7 +45,7 @@ ln -snf /host/usr/include/processor_sdk /usr/include/processor_sdk
 ln -snf /host/usr/lib/libIL.so.1 /usr/lib/libIL.so.1
 ln -snf /host/usr/lib/libILU.so.1 /usr/lib/libILU.so.1
 ln -snf /host/usr/lib/libtivision_apps.so /usr/lib/libtivision_apps.so
-ln -snf /host/usr/lib/libtivision_apps.so.11.0.0 /usr/lib/libtivision_apps.so.11.0.0
+ln -snf /host/usr/lib/libtivision_apps.so.11.1.0 /usr/lib/libtivision_apps.so.11.1.0
 ln -snf /host/usr/lib/libti_rpmsg_char.so.0 /usr/lib/libti_rpmsg_char.so.0
 
 # Softlink update required for v4l2h264enc

--- a/init_script.sh
+++ b/init_script.sh
@@ -75,5 +75,5 @@ export EDGEAI_GST_APPS_PATH=/opt/edgeai-gst-apps
 export EDGEAI_DATA_PATH=/opt/edgeai-test-data
 export OOB_DEMO_ASSETS_PATH=/opt/oob-demo-assets
 export MODEL_ZOO_PATH=/opt/model_zoo
-export EDGEAI_VERSION=11.0
-export EDGEAI_SDK_VERSION=11_00_00
+export EDGEAI_VERSION=11.1
+export EDGEAI_SDK_VERSION=11_01_00

--- a/scripts/install_apps_utils.sh
+++ b/scripts/install_apps_utils.sh
@@ -33,7 +33,7 @@
 current_dir=$(pwd)
 cd $(dirname $0)
 
-branch_name=EDGEAI_APP_STACK_11_00_00_00
+branch_name=EDGEAI_APP_STACK_11_01_00_00
 
 if [ `arch` == "aarch64" ]; then
     install_dir="/opt/"

--- a/scripts/install_dl_inferer.sh
+++ b/scripts/install_dl_inferer.sh
@@ -33,7 +33,7 @@
 current_dir=$(pwd)
 cd $(dirname $0)
 
-branch_name=EDGEAI_APP_STACK_11_00_00_00
+branch_name=EDGEAI_APP_STACK_11_01_00_00
 
 if [ `arch` == "aarch64" ]; then
     install_dir="/opt/"

--- a/scripts/install_gst_plugins.sh
+++ b/scripts/install_gst_plugins.sh
@@ -39,7 +39,7 @@ else
     install_dir="../../"
 fi
 
-branch_name=EDGEAI_APP_STACK_11_00_00_00
+branch_name=EDGEAI_APP_STACK_11_01_00_00
 
 while getopts ":i:b:d" flag; do
     case "${flag}" in

--- a/scripts/install_tiovx_kernels.sh
+++ b/scripts/install_tiovx_kernels.sh
@@ -33,7 +33,7 @@
 current_dir=$(pwd)
 cd $(dirname $0)
 
-branch_name=EDGEAI_APP_STACK_11_00_00_00
+branch_name=EDGEAI_APP_STACK_11_01_00_00
 
 if [ `arch` == "aarch64" ]; then
     install_dir="/opt/"

--- a/scripts/install_tiovx_modules.sh
+++ b/scripts/install_tiovx_modules.sh
@@ -33,7 +33,7 @@
 current_dir=$(pwd)
 cd $(dirname $0)
 
-branch_name=EDGEAI_APP_STACK_11_00_00_00
+branch_name=EDGEAI_APP_STACK_11_01_00_00
 
 if [ `arch` == "aarch64" ]; then
     install_dir="/opt/"


### PR DESCRIPTION
* Update EDGEAI_VERSION and EDGEAI_APP_STACK to 11_01_00 for EdgeAI SDK RC1 for AM62A

* While at it, also update the version for libtivision_apps.so since sdk_builder got updated for the same [0]

[0]: https://git.ti.com/cgit/processor-sdk/sdk_builder/commit/?h=main&id=c1cf277c5eac17477e71087835e2eeee8fe10c53